### PR TITLE
dump-snapshot and dump-epoch-snapshots commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,31 +92,48 @@ immutable chain is used.
 |-------|------|-------------|
 | `epoch` | integer | Epoch number |
 | `snapshotEraName` | string | Name of the era at the snapshot point |
+| `epochNonce` | string \| null | Epoch nonce (η₀) used for slot-leader VRF verification. Hex-encoded Blake2b-256 hash, or `null` for the neutral nonce or Byron era. |
 | `protocolParams` | object | Protocol parameters relevant to reward calculations (see below) |
 | `activeStake` | integer | Total lovelace delegated in the **go** snapshot (lovelace) |
-| `eta` | number | Epoch performance multiplier: `min(1, blocksMade / expectedBlocks)`. Set to 1 when `d ≥ 0.8` |
+| `eta` | object \| null | Epoch performance multiplier as exact rational `{"numerator": n, "denominator": d}`, representing `min(1, blocksMade / expectedBlocks)`. Set to `{"numerator": 1, "denominator": 1}` when `d ≥ 0.8`. `null` when genesis globals are unavailable. |
 | `expectedBlocks` | integer | Number of blocks expected this epoch: `(1 - d) * f * epochSize` |
-| `rupdNext` | object | Reward update for the **next** epoch transition (see below) |
+| `rupdNext` | object | Reward update computed for the **next** epoch transition (see below) |
+| `rupdApplied` | object \| null | Reward update that was **applied at this epoch boundary** (i.e., the `rupdNext` from the previous epoch). `null` for the first epoch or when not available. |
 | `treasury` | integer | Current treasury balance (lovelace) |
 | `reserves` | integer | Current reserves balance (lovelace) |
 | `totalPools` | integer | Number of pools in the current pool distribution |
-| `poolDistribution` | array | Per-pool stake fractions for the current epoch |
+| `poolDistribution` | array | Per-pool stake fractions for the current epoch (see below) |
 | `epochFees` | integer | Fees collected during the previous epoch (lovelace); feeds into `rPot` |
+| `totalStake` | integer | Total lovelace in circulation: `maxLovelaceSupply - reserves`. `null` if genesis globals are unavailable. |
 | `deposits` | object | Outstanding deposit obligations: `stakeKey`, `pool`, `dRep`, `proposal`, `total` (lovelace) |
 | `instantaneousRewards` | object | Pending MIR transfers queued for the next epoch boundary (Shelley–Babbage only; always empty in Conway+). Fields: `iRReserves`, `iRTreasury` (credential→lovelace maps), `deltaReserves`, `deltaTreasury` (DeltaCoin adjustments). |
+| `conwayGov` | object \| null | Conway governance state (see below). `null` for pre-Conway eras. |
 | `snapshots` | object | The three stake snapshots: `mark` (N+1), `set` (N), `go` (N-1) |
 
 ##### `protocolParams`
 
+All rational fields are encoded as exact fractions `{"numerator": n, "denominator": d}` to avoid floating-point rounding errors.
+
 | Field | Description |
 |-------|-------------|
-| `rho` | Monetary expansion rate |
-| `tau` | Treasury expansion rate |
-| `d` | Decentralisation parameter (0 = fully decentralised) |
-| `a0` | Pool pledge influence |
+| `rho` | Monetary expansion rate (exact rational) |
+| `tau` | Treasury expansion rate (exact rational) |
+| `d` | Decentralisation parameter (exact rational; 0 = fully decentralised) |
+| `a0` | Pool pledge influence (exact rational) |
 | `nOpt` | Desired number of pools (k parameter, used for saturation) |
 | `minPoolCost` | Minimum pool operating cost (lovelace) |
 | `protocolVersion` | `{ major, minor }` |
+
+##### `poolDistribution` entries
+
+Each entry in the `poolDistribution` array has:
+
+| Field | Description |
+|-------|-------------|
+| `poolId` | Pool key hash (hex) |
+| `stake` | Pool's fractional stake as exact rational `{"numerator": n, "denominator": d}` |
+| `stakeLovelace` | Pool's total delegated stake in lovelace (integer, includes proposal deposits) |
+| `stakePercent` | Pool's stake as a percentage (approximate floating-point, for display only) |
 
 ##### `rupdNext`
 
@@ -154,6 +171,18 @@ Each of `mark`, `set`, and `go` contains:
 | `delegations` | Map of stake credential → pool ID |
 | `poolParams` | Map of pool ID → pool registration parameters |
 | `blocks` | Map of pool ID → blocks made this epoch (**mark** uses `nesBcur`; **go** uses `nesBprev`; **set** omits this field because the epoch N-2 block data is no longer retained) |
+
+##### `conwayGov`
+
+Present only in Conway and later eras. The DRep pulser is forced to completion before extracting this data.
+
+| Field | Description |
+|-------|-------------|
+| `drepDistr` | Map of DRep credential/sentinel → lovelace stake; produced by forcing the DRep pulser to completion |
+| `committee` | Currently enacted Constitutional Committee: member credentials with their expiry epochs and the threshold required for valid votes |
+| `constitution` | Currently enacted Constitution: anchor (URL + hash) and optional guardrail script hash |
+| `committeeState` | Hot key authorizations and resignations for CC members (maps cold credential → hot credential status) |
+| `nextEnactState` | Ratified governance state queued for enactment at the next epoch boundary. Includes `committee`, `constitution`, `curPParams`, `prevPParams`, `treasury` (pending withdrawals), and `prevGovActionIds` (last enacted action ID per proposal category) |
 
 ### Benchmarking
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ immutable chain is used.
 
 #### JSON schema
 
+For `dump-epoch-snapshots`, each file is written at the first block of the new epoch rather than at the bare boundary slot; all epoch-boundary transitions (reward distribution, treasury/reserve updates, snapshot rotation) have already been applied, so all fields reflect the post-boundary state.
+
 | Field | Type | Description |
 |-------|------|-------------|
 | `epoch` | integer | Epoch number |

--- a/README.md
+++ b/README.md
@@ -67,6 +67,94 @@ $ cabal run -- cardano-node run --topology configuration/cardano/mainnet-topolog
 
 ## Executing
 
+### Dump Snapshot
+
+The `dump-snapshot` command reads a ledger snapshot from a Cardano node chain
+database and emits a JSON document to stdout with the data needed to verify
+epoch reward, treasury, and reserve calculations. It is primarily intended as
+a reference dataset for alternative Cardano node implementations.
+
+```shell
+$ cstreamer dump-snapshot \
+    --config=/path/to/cardano-node-config.json \
+    --chain-dir=/path/to/chain/db \
+    --start-slot=<slot-at-epoch-boundary> \
+    > epoch-N-slot-S.json
+```
+
+The `--start-slot` value should point to a snapshot that was written by
+`cardano-node` with `--write-snapshot <slot>`. If omitted, the tip of the
+immutable chain is used.
+
+#### JSON schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `epoch` | integer | Epoch number |
+| `snapshotEraName` | string | Name of the era at the snapshot point |
+| `protocolParams` | object | Protocol parameters relevant to reward calculations (see below) |
+| `activeStake` | integer | Total lovelace delegated in the **go** snapshot (lovelace) |
+| `eta` | number | Epoch performance multiplier: `min(1, blocksMade / expectedBlocks)`. Set to 1 when `d ≥ 0.8` |
+| `expectedBlocks` | integer | Number of blocks expected this epoch: `(1 - d) * f * epochSize` |
+| `rupdNext` | object | Reward update for the **next** epoch transition (see below) |
+| `treasury` | integer | Current treasury balance (lovelace) |
+| `reserves` | integer | Current reserves balance (lovelace) |
+| `totalPools` | integer | Number of pools in the current pool distribution |
+| `poolDistribution` | array | Per-pool stake fractions for the current epoch |
+| `epochFees` | integer | Fees collected during the previous epoch (lovelace); feeds into `rPot` |
+| `deposits` | object | Outstanding deposit obligations: `stakeKey`, `pool`, `dRep`, `proposal`, `total` (lovelace) |
+| `instantaneousRewards` | object | Pending MIR transfers queued for the next epoch boundary (Shelley–Babbage only; always empty in Conway+). Fields: `iRReserves`, `iRTreasury` (credential→lovelace maps), `deltaReserves`, `deltaTreasury` (DeltaCoin adjustments). |
+| `snapshots` | object | The three stake snapshots: `mark` (N+1), `set` (N), `go` (N-1) |
+
+##### `protocolParams`
+
+| Field | Description |
+|-------|-------------|
+| `rho` | Monetary expansion rate |
+| `tau` | Treasury expansion rate |
+| `d` | Decentralisation parameter (0 = fully decentralised) |
+| `a0` | Pool pledge influence |
+| `nOpt` | Desired number of pools (k parameter, used for saturation) |
+| `minPoolCost` | Minimum pool operating cost (lovelace) |
+| `protocolVersion` | `{ major, minor }` |
+
+##### `rupdNext`
+
+All amounts are in lovelace. The object shape depends on whether the reward
+pulser was still in progress at the snapshot point:
+
+**Pulsing / not-yet-started** (most common — the pulser is forced to
+completion by `cardano-streamer`):
+
+| Field | Description |
+|-------|-------------|
+| `deltaR1` | Amount taken from reserves (`rho × reserves`) |
+| `deltaR2` | Unclaimed rewards returned to reserves (`rewardPot - totalDistributed`) |
+| `deltaT1` | Amount sent to treasury (`tau × rPot`) |
+| `rPot` | Total reward pot: `epochFees + deltaR1` |
+| `rewardPot` | Amount available for distribution: `rPot - deltaT1` |
+| `totalDistributed` | Total actually distributed to stake credentials |
+
+**Complete** (pulser already finished before snapshot was taken):
+
+| Field | Description |
+|-------|-------------|
+| `deltaT1` | Amount sent to treasury |
+| `deltaR` | Net reserves change: `deltaR2 - deltaR1` (negative = net taken from reserves) |
+| `totalDistributed` | Total distributed to stake credentials |
+
+##### `snapshots`
+
+Each of `mark`, `set`, and `go` contains:
+
+| Field | Description |
+|-------|-------------|
+| `name` | Snapshot name (`mark`, `set`, or `go`) |
+| `stake` | Map of stake credential → lovelace |
+| `delegations` | Map of stake credential → pool ID |
+| `poolParams` | Map of pool ID → pool registration parameters |
+| `blocks` | Map of pool ID → blocks made this epoch (**mark** uses `nesBcur`; **go** uses `nesBprev`; **set** omits this field because the epoch N-2 block data is no longer retained) |
+
 ### Benchmarking
 
 Here is an example on how to benchmark validation from one slot to another

--- a/app/CLI.hs
+++ b/app/CLI.hs
@@ -208,6 +208,20 @@ commandParser =
             "dump-snapshot"
             (info (pure DumpSnapshot) (progDesc "Dump ledger snapshot as JSON"))
       )
+    <|> subparser
+      ( metavar "dump-epoch-snapshots"
+          <> command
+            "dump-epoch-snapshots"
+            ( info
+                (pure DumpEpochSnapshots)
+                ( progDesc $
+                    mconcat
+                      [ "Replay the chain from --start-slot to tip, writing one JSON snapshot "
+                      , "file per epoch to --out-dir at the first block of each new epoch."
+                      ]
+                )
+            )
+      )
 
 rewardsCommandParser :: Parser Command
 rewardsCommandParser =

--- a/app/CLI.hs
+++ b/app/CLI.hs
@@ -202,6 +202,12 @@ commandParser =
             "rewards"
             (info rewardsCommandParser (progDesc "Calculate Rewards and Wthdrawals per Epoch"))
       )
+    <|> subparser
+      ( metavar "dump-snapshot"
+          <> command
+            "dump-snapshot"
+            (info (pure DumpSnapshot) (progDesc "Dump ledger snapshot as JSON"))
+      )
 
 rewardsCommandParser :: Parser Command
 rewardsCommandParser =

--- a/cardano-streamer.cabal
+++ b/cardano-streamer.cabal
@@ -77,6 +77,7 @@ library
                      , ouroboros-consensus-diffusion
                      , ouroboros-network-api
                      , io-classes
+                     , microlens
                      , nothunks
                      , profunctors
                      , resource-registry
@@ -89,6 +90,7 @@ library
                      , transformers
                      , unliftio
                      , vector
+                     , vector-map
                      , sop-core
                      , sop-extras
 

--- a/src/Cardano/Streamer/Common.hs
+++ b/src/Cardano/Streamer/Common.hs
@@ -242,6 +242,7 @@ data Command
   | Benchmark
   | Stats
   | ComputeRewards (NonEmpty RewardAccount)
+  | DumpSnapshot
   deriving (Show)
 
 instance Display Command where
@@ -250,6 +251,7 @@ instance Display Command where
     Benchmark -> "Benchmark"
     Stats -> "Compute Statistics"
     ComputeRewards _xs -> "Compute Rewards" -- for: " <> intersperce "," (map displayShow xs)
+    DumpSnapshot -> "Dump Snapshot"
 
 newtype BlockHashOrSlotNo = BlockHashOrSlotNo
   {unBlockHashOrSlotNo :: Either SlotNo (Hash HASH EraIndependentBlockHeader)}

--- a/src/Cardano/Streamer/Common.hs
+++ b/src/Cardano/Streamer/Common.hs
@@ -243,6 +243,7 @@ data Command
   | Stats
   | ComputeRewards (NonEmpty RewardAccount)
   | DumpSnapshot
+  | DumpEpochSnapshots
   deriving (Show)
 
 instance Display Command where
@@ -252,6 +253,7 @@ instance Display Command where
     Stats -> "Compute Statistics"
     ComputeRewards _xs -> "Compute Rewards" -- for: " <> intersperce "," (map displayShow xs)
     DumpSnapshot -> "Dump Snapshot"
+    DumpEpochSnapshots -> "Dump All Epoch Snapshots"
 
 newtype BlockHashOrSlotNo = BlockHashOrSlotNo
   {unBlockHashOrSlotNo :: Either SlotNo (Hash HASH EraIndependentBlockHeader)}

--- a/src/Cardano/Streamer/Ledger.hs
+++ b/src/Cardano/Streamer/Ledger.hs
@@ -89,7 +89,8 @@ appScriptSize :: AppScript -> Int
 appScriptSize = SBS.length . appScriptBytes
 
 class
-  ( EraBlockBody era
+  ( Era era
+  , EraBlockBody era
   , EraGov era
   , EraUTxO era
   , EraStake era

--- a/src/Cardano/Streamer/LedgerState.hs
+++ b/src/Cardano/Streamer/LedgerState.hs
@@ -30,6 +30,7 @@ module Cardano.Streamer.LedgerState (
   writeNewEpochState,
   extLedgerStateCardanoEra,
   extLedgerStateEpochNo,
+  extLedgerStateEpochNonce,
   extractLedgerEvents,
   readGenesis,
   mkGlobals,
@@ -134,7 +135,9 @@ import Ouroboros.Consensus.Shelley.Ledger.Block
 import Ouroboros.Consensus.Shelley.Ledger.Ledger
 import Ouroboros.Consensus.Shelley.Ledger.SupportsProtocol ()
 import Ouroboros.Consensus.Shelley.ShelleyHFC ()
-import Ouroboros.Consensus.TypeFamilyWrappers (WrapLedgerEvent (..), WrapTipInfo (..))
+import Cardano.Protocol.TPraos.API (ChainDepState (csTickn))
+import Cardano.Protocol.TPraos.Rules.Tickn (TicknState (ticknStateEpochNonce))
+import Ouroboros.Consensus.TypeFamilyWrappers (WrapChainDepState (..), WrapLedgerEvent (..), WrapTipInfo (..))
 import qualified RIO.Map as Map
 import qualified RIO.Text as T
 
@@ -670,6 +673,27 @@ extLedgerStateEpochNo =
   applyNewEpochState
     (EpochNo . Byron.getEpochNumber . Byron.currentEpoch . Byron.cvsUpdateState)
     (const nesEL)
+
+-- | Extract the epoch nonce (η₀) from the current era's chain dep state.
+-- Returns Nothing for Byron which uses a different consensus protocol.
+-- For Shelley–Alonzo (TPraos) the nonce lives in TicknState; for
+-- Babbage–Dijkstra (Praos) it is stored directly on PraosState.
+extLedgerStateEpochNonce :: ExtLedgerState (CardanoBlock c) mk -> Maybe Nonce
+extLedgerStateEpochNonce extLedgerState =
+  case State.getHardForkState (headerStateChainDep (headerState extLedgerState)) of
+    TeleByron _ -> Nothing
+    TeleShelley _ curr -> Just $ fromTPraos curr
+    TeleAllegra _ _ curr -> Just $ fromTPraos curr
+    TeleMary _ _ _ curr -> Just $ fromTPraos curr
+    TeleAlonzo _ _ _ _ curr -> Just $ fromTPraos curr
+    TeleBabbage _ _ _ _ _ curr -> Just $ fromPraos curr
+    TeleConway _ _ _ _ _ _ curr -> Just $ fromPraos curr
+    TeleDijkstra _ _ _ _ _ _ _ curr -> Just $ fromPraos curr
+  where
+    fromTPraos (State.Current{State.currentState = WrapChainDepState st}) =
+      ticknStateEpochNonce . csTickn $ tpraosStateChainDepState st
+    fromPraos (State.Current{State.currentState = WrapChainDepState st}) =
+      praosStateEpochNonce st
 
 tickedExtLedgerStateEpochNo ::
   Ticked (ExtLedgerState (CardanoBlock c)) mk ->

--- a/src/Cardano/Streamer/LedgerState.hs
+++ b/src/Cardano/Streamer/LedgerState.hs
@@ -18,6 +18,7 @@ module Cardano.Streamer.LedgerState (
   readNewEpochState,
   encodeNewEpochState,
   applyNonByronNewEpochState,
+  applyConwayNewEpochState,
   applyNewEpochState,
   modifyLedgerState,
   applyTickedNewEpochStateWithBlock,
@@ -102,6 +103,8 @@ import Data.SOP.Telescope
 import Ouroboros.Consensus.Byron.ByronHFC ()
 import Ouroboros.Consensus.Byron.Ledger.Block
 import Ouroboros.Consensus.Byron.Ledger.Ledger
+import Cardano.Ledger.Conway.Governance (ConwayEraGov)
+import Cardano.Ledger.Conway.State (ConwayEraCertState)
 import Ouroboros.Consensus.Cardano.Block
 import Ouroboros.Consensus.Config (TopLevelConfig (..))
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (
@@ -580,6 +583,16 @@ applyNonByronNewEpochState ::
   ExtLedgerState (CardanoBlock c) mk ->
   Maybe a
 applyNonByronNewEpochState f = applyNewEpochState (const Nothing) (\_ -> Just . f)
+
+applyConwayNewEpochState ::
+  (forall era. (ConwayEraGov era, ConwayEraCertState era) => NewEpochState era -> a) ->
+  ExtLedgerState (CardanoBlock c) mk ->
+  Maybe a
+applyConwayNewEpochState f extLedgerState =
+  case ledgerState extLedgerState of
+    LedgerStateConway ls -> Just $ f (shelleyLedgerState ls)
+    LedgerStateDijkstra ls -> Just $ f (shelleyLedgerState ls)
+    _ -> Nothing
 
 applyTickedNewEpochState ::
   (TransitionInfo -> ChainValidationState -> a) ->

--- a/src/Cardano/Streamer/Run.hs
+++ b/src/Cardano/Streamer/Run.hs
@@ -13,20 +13,70 @@
 module Cardano.Streamer.Run (runApp) where
 
 import Cardano.Ledger.Address
+import Cardano.Ledger.BaseTypes (
+  BlocksMade (..),
+  BoundedRational (..),
+  EpochNo (..),
+  StrictMaybe (..),
+  activeSlotCoeff,
+  activeSlotVal,
+  epochInfoPure,
+  maxLovelaceSupply,
+  securityParameter,
+  )
+import Cardano.Ledger.Slot (EpochSize (..), epochInfoSize)
+import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
+import Cardano.Ledger.Compactible (fromCompact)
+import Cardano.Ledger.Core (
+  Reward (..),
+  ppA0L,
+  ppDG,
+  ppMinPoolCostL,
+  ppNOptL,
+  ppProtocolVersionL,
+  ppRhoL,
+  ppTauL,
+  )
+import Cardano.Ledger.Conway.Governance (
+  ConwayEraGov (committeeGovStateL, constitutionGovStateL),
+  finishDRepPulser,
+  newEpochStateDRepPulsingStateL,
+  rsEnactStateL,
+  )
+import Cardano.Ledger.Conway.State (ConwayEraCertState, certVStateL, vsCommitteeStateL)
+import Cardano.Ledger.Shelley.RewardUpdate (PulsingRewUpdate (..), RewardSnapShot (..), RewardUpdate (..))
+import Cardano.Ledger.Hashes (unKeyHash)
+import Cardano.Crypto.Hash.Class (hashToTextAsHex)
+import Cardano.Ledger.PoolDistr (PoolDistr (..))
+import qualified Cardano.Ledger.PoolDistr as PD
+import Cardano.Ledger.Shelley.API (SnapShot (..), SnapShots (..), Stake (..))
+import Cardano.Ledger.Shelley.LedgerState
+import Cardano.Ledger.State (Obligations (..), obligationCertState, obligationGovState, sumAllStake, sumObligation)
+import qualified Data.VMap as VMap
 import Cardano.Streamer.Benchmark
 import Cardano.Streamer.Common
 import Cardano.Streamer.Inspection
 import Cardano.Streamer.LedgerState
 import Cardano.Streamer.Producer
 import Cardano.Streamer.ProtocolInfo
+import Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
 import Cardano.Streamer.RTS
 import Cardano.Streamer.Rewards
+import Cardano.Ledger.Conway.Governance.DRepPulser (psDRepDistr)
+import Cardano.Streamer.Storage (ledgerDbTipExtLedgerState)
 import Conduit
 import Control.ResourceRegistry (withRegistry)
 import Criterion.Measurement (initializeTime)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.Char (toLower)
 import qualified Data.List.NonEmpty as NE
+import Control.Monad.Trans.Reader (runReaderT)
+import Data.Functor.Identity (runIdentity)
 import qualified Data.Map.Strict as Map
+import Lens.Micro ((^.))
+import Ouroboros.Consensus.Ledger.Extended (ledgerState)
+import Ouroboros.Consensus.Shelley.Ledger.Ledger (shelleyLedgerState)
 import Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import Ouroboros.Consensus.Storage.LedgerDB.Snapshots (DiskSnapshot (..))
 import RIO.Directory (createDirectoryIfMissing, doesDirectoryExist, doesPathExist, listDirectory)
@@ -57,6 +107,202 @@ replayEpochStats = do
   writeNamedCsv "EpochStats" (epochStatsToNamedCsv epochStats)
   logInfo $ "Final summary: \n    " <> display (fold $ unEpochStats epochStats)
 
+dumpLedgerSnapshot :: RIO App ()
+dumpLedgerSnapshot = do
+  extLedgerState <- ledgerDbTipExtLedgerState
+  app <- ask
+  let eraName = show $ extLedgerStateCardanoEra extLedgerState
+      mGlobals =
+        globalsFromLedgerConfig
+          (extLedgerStateCardanoEra extLedgerState)
+          extLedgerState
+          (pInfoConfig (dsAppProtocolInfo app))
+      mConwayGov = applyConwayNewEpochState extractConwayGovData extLedgerState
+      maybeData = applyNonByronNewEpochState (extractSnapshotData eraName mGlobals mConwayGov) extLedgerState
+  case maybeData of
+    Just snapshotData -> liftIO $ BSL.putStrLn $ Aeson.encode snapshotData
+    Nothing -> logError "Cannot dump Byron era snapshot"
+  where
+    extractConwayGovData ::
+      (ConwayEraGov era, ConwayEraCertState era) => NewEpochState era -> Aeson.Value
+    extractConwayGovData nes =
+      let (snap, ratifyState) = finishDRepPulser (nes ^. newEpochStateDRepPulsingStateL)
+          drepDistr = Map.map fromCompact (psDRepDistr snap)
+          committee = nes ^. newEpochStateGovStateL . committeeGovStateL
+          constitution = nes ^. newEpochStateGovStateL . constitutionGovStateL
+          committeeState =
+            nes ^. nesEpochStateL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
+          nextEnactState = ratifyState ^. rsEnactStateL
+       in Aeson.object
+            [ "drepDistr" Aeson..= drepDistr
+            , "committee" Aeson..= committee
+            , "constitution" Aeson..= constitution
+            , "committeeState" Aeson..= committeeState
+            , "nextEnactState" Aeson..= nextEnactState
+            ]
+
+    extractSnapshotData eraName mGlobals mConwayGov nes =
+      let epochNum = case nesEL nes of EpochNo n -> n
+          epochState = nesEs nes
+          poolDistr = nesPd nes
+          accountState = epochState ^. esAccountStateL
+          treasuryAmt = unCoin $ accountState ^. asTreasuryL
+          reservesAmt = unCoin $ accountState ^. asReservesL
+
+          -- Extract all 3 snapshots (mark, set, go) and fees
+          SnapShots {ssStakeMark = markSnap, ssStakeSet = setSnap, ssStakeGo = goSnap, ssFee = feeCoin} = epochState ^. esSnapshotsL
+          fees = unCoin feeCoin
+
+          -- Extract deposit obligations
+          obligations = obligationCertState (epochState ^. esLStateL . lsCertStateL)
+                     <> obligationGovState (nes ^. newEpochStateGovStateL)
+
+          -- Extract reward update data, forcing the pulser to completion if needed.
+          -- For SNothing (before stability point), synthesize via startStep.
+          rupdData =
+            let sumRs m =
+                  sum
+                    [ unCoin (rewardAmount r)
+                    | rs_set <- Map.elems m
+                    , r <- Set.toList rs_set
+                    ] :: Integer
+                fromPulsing globals rewsnap@RewardSnapShot {..} pulser =
+                  let Coin rPot' = rewFees <> rewDeltaR1
+                      (RewardUpdate {rs = forcedRs}, _) =
+                        runIdentity $ runReaderT (completeRupd (Pulsing rewsnap pulser)) globals
+                      totalDistributed = sumRs forcedRs
+                      deltaR2 = unCoin rewR - totalDistributed
+                   in Aeson.object
+                        [ "deltaR1" Aeson..= unCoin rewDeltaR1
+                        , "deltaR2" Aeson..= deltaR2
+                        , "deltaT1" Aeson..= unCoin rewDeltaT1
+                        , "rPot" Aeson..= rPot'
+                        , "rewardPot" Aeson..= unCoin rewR
+                        , "totalDistributed" Aeson..= totalDistributed
+                        ]
+             in case (nesRu nes, mGlobals) of
+                  (SJust (Complete RewardUpdate {..}), _) ->
+                    let DeltaCoin deltaT1 = deltaT
+                        DeltaCoin deltaRCombined = deltaR
+                     in Aeson.object
+                          [ "deltaT1" Aeson..= deltaT1
+                          , "deltaR" Aeson..= deltaRCombined
+                          , "totalDistributed" Aeson..= sumRs rs
+                          ]
+                  (_, Nothing) -> Aeson.Null
+                  (SJust (Pulsing rewsnap pulser), Just globals) ->
+                    fromPulsing globals rewsnap pulser
+                  (SNothing, Just globals) ->
+                    let pulsing =
+                          startStep
+                            (epochInfoSize (epochInfoPure globals) (nesEL nes))
+                            (nesBprev nes)
+                            (nesEs nes)
+                            (Coin $ fromIntegral $ maxLovelaceSupply globals)
+                            (activeSlotCoeff globals)
+                            (securityParameter globals)
+                     in case pulsing of
+                          Pulsing rewsnap pulser -> fromPulsing globals rewsnap pulser
+                          Complete RewardUpdate {..} ->
+                            Aeson.object ["totalDistributed" Aeson..= sumRs rs]
+
+          -- Protocol parameters relevant to reward/treasury calculation
+          pr = epochState ^. prevPParamsEpochStateL
+          protoParams =
+            Aeson.object
+              [ "rho" Aeson..= (fromRational (unboundRational (pr ^. ppRhoL)) :: Double)
+              , "tau" Aeson..= (fromRational (unboundRational (pr ^. ppTauL)) :: Double)
+              , "d" Aeson..= (fromRational (unboundRational (pr ^. ppDG)) :: Double)
+              , "a0" Aeson..= (fromRational (unboundRational (pr ^. ppA0L)) :: Double)
+              , "nOpt" Aeson..= (pr ^. ppNOptL)
+              , "minPoolCost" Aeson..= unCoin (pr ^. ppMinPoolCostL)
+              , "protocolVersion" Aeson..= (pr ^. ppProtocolVersionL)
+              ]
+
+          -- Circulation and active stake
+          totalStake = case mGlobals of
+            Nothing -> Nothing
+            Just globals ->
+              Just $ fromIntegral (maxLovelaceSupply globals) - reservesAmt :: Maybe Integer
+          activeStake = unCoin $ sumAllStake (ssStake goSnap)
+
+          -- Pending MIR transfers (Shelley–Babbage; always empty in Conway+)
+          instantaneousRewards =
+            epochState ^. esLStateL . lsCertStateL . certDStateL . dsIRewardsL
+
+          -- Eta (performance multiplier) and expected blocks
+          etaAndExpected = mGlobals <&> \globals ->
+            let d = unboundRational (pr ^. ppDG)
+                EpochSize slots = epochInfoSize (epochInfoPure globals) (nesEL nes)
+                asc = activeSlotCoeff globals
+                expectedBlocks =
+                  floor $ (1 - d) * unboundRational (activeSlotVal asc) * fromIntegral slots :: Integer
+                blocksMadeCount =
+                  fromIntegral $ Map.foldr (+) 0 (unBlocksMade (nesBprev nes)) :: Integer
+                eta :: Double
+                eta
+                  | d >= 0.8 = 1.0
+                  | expectedBlocks == 0 = 1.0
+                  | otherwise = fromIntegral blocksMadeCount / fromIntegral expectedBlocks
+             in (eta, expectedBlocks)
+
+          poolMap = PD.unPoolDistr poolDistr
+          totalStakeRational = sum [PD.individualPoolStake pd | pd <- Map.elems poolMap]
+          poolCount = Map.size poolMap
+          poolEntries = map mkPoolEntry (Map.toList poolMap)
+            where
+              mkPoolEntry (pid, poolData) =
+                let stakeRational = PD.individualPoolStake poolData
+                    percent =
+                      if totalStakeRational > 0
+                        then fromRational (stakeRational / totalStakeRational * 100) :: Double
+                        else 0
+                 in Aeson.object
+                      [ "poolId" Aeson..= hashToTextAsHex (unKeyHash pid),
+                        "stake" Aeson..= (fromRational stakeRational :: Double),
+                        "stakePercent" Aeson..= percent
+                      ]
+
+          -- Helper to extract full snapshot data for comparison
+          snapshotInfo name mBlocks snap =
+            Aeson.object $
+              [ "name" Aeson..= (name :: String)
+              , "stake" Aeson..= ssStake snap
+              , "delegations" Aeson..= ssDelegations snap
+              , "poolParams" Aeson..= ssPoolParams snap
+              ]
+                ++ ["blocks" Aeson..= b | Just b <- [mBlocks]]
+
+       in Aeson.object
+            [ "epoch" Aeson..= (fromIntegral epochNum :: Integer),
+              "snapshotEraName" Aeson..= eraName,
+              "protocolParams" Aeson..= protoParams,
+              "totalStake" Aeson..= totalStake,
+              "activeStake" Aeson..= activeStake,
+              "eta" Aeson..= fmap fst etaAndExpected,
+              "expectedBlocks" Aeson..= fmap snd etaAndExpected,
+              "rupdNext" Aeson..= rupdData,
+              "treasury" Aeson..= treasuryAmt,
+              "reserves" Aeson..= reservesAmt,
+              "totalPools" Aeson..= poolCount,
+              "poolDistribution" Aeson..= poolEntries,
+              "epochFees" Aeson..= fees,
+              "deposits" Aeson..= Aeson.object
+                [ "stakeKey" Aeson..= unCoin (oblStake obligations)
+                , "pool" Aeson..= unCoin (oblPool obligations)
+                , "dRep" Aeson..= unCoin (oblDRep obligations)
+                , "proposal" Aeson..= unCoin (oblProposal obligations)
+                , "total" Aeson..= unCoin (sumObligation obligations)
+                ],
+              "instantaneousRewards" Aeson..= instantaneousRewards,
+              "conwayGov" Aeson..= mConwayGov,
+              "snapshots" Aeson..= Aeson.object
+                [ "mark" Aeson..= snapshotInfo "mark" (Just (nesBcur nes)) markSnap
+                , "set" Aeson..= snapshotInfo "set" (Nothing :: Maybe BlocksMade) setSnap
+                , "go" Aeson..= snapshotInfo "go" (Just (nesBprev nes)) goSnap
+                ]
+            ]
+
 replayRewards :: NE.NonEmpty RewardAccount -> RIO App ()
 replayRewards accounts = do
   mOutDir <- dsAppOutDir <$> ask
@@ -65,10 +311,10 @@ replayRewards accounts = do
       logError "Output directory is required for exporting rewards"
     Just outDir -> do
       let filePaths =
-            [ ( raCredential account
-              , outDir </> T.unpack (formatRewardAccount account) <.> "csv"
+            [ ( raCredential account,
+                outDir </> T.unpack (formatRewardAccount account) <.> "csv"
               )
-            | account <- NE.toList accounts
+              | account <- NE.toList accounts
             ]
           withRewardsFiles action = go [] filePaths
             where
@@ -80,7 +326,7 @@ replayRewards accounts = do
           transformAndFilterRewards handles rd = do
             let filteredRewardsWithHandles = Map.intersectionWith (,) handles (rdRewards rd)
             guard (not (Map.null filteredRewardsWithHandles))
-            Just $ map (\(h, c) -> (h, rd{rdRewards = c})) $ Map.elems filteredRewardsWithHandles
+            Just $ map (\(h, c) -> (h, rd {rdRewards = c})) $ Map.elems filteredRewardsWithHandles
       withRewardsFiles $ \rewardHandles -> do
         writeRewardsHeaders rewardHandles
         runConduit $
@@ -89,14 +335,14 @@ replayRewards accounts = do
             .| mapM_C (mapM_ (uncurry writeRewardDistribution))
 
 runApp :: Opts -> IO ()
-runApp Opts{..} = do
+runApp Opts {..} = do
   -- Consensus code will initialize the chain directory if it doesn't exist, which makes
   -- no sense for a tool that is suppose to be read only.
   unlessM (doesDirectoryExist oChainDir) $ do
     throwString $ "Chain directory does not exist: " <> oChainDir
   whenM (null <$> listDirectory oChainDir) $ do
     throwString $ "Chain directory is empty: " <> oChainDir
-  logOpts <- logOptionsHandle stdout oVerbose
+  logOpts <- logOptionsHandle stderr oVerbose
   withLogFunc (setLogMinLevel oLogLevel $ setLogUseLoc oDebug logOpts) $ \logFunc -> do
     withRegistry $ \registry -> do
       let (writeBlockSlots, writeBlockHashes) =
@@ -105,18 +351,18 @@ runApp Opts{..} = do
                 map unBlockHashOrSlotNo oWriteBlocks
           appConf =
             AppConfig
-              { appConfChainDir = oChainDir
-              , appConfFilePath = oConfigFilePath
-              , appConfReadDiskSnapshot =
-                  DiskSnapshot <$> oReadSnapShotSlotNumber <*> pure oSnapShotSuffix
-              , appConfWriteDiskSnapshots =
-                  DiskSnapshot <$> oWriteSnapShotSlotNumbers <*> pure oSnapShotSuffix
-              , appConfStopSlotNumber = oStopSlotNumber
-              , appConfValidationMode = oValidationMode
-              , appConfWriteBlocksSlotNoSet = writeBlockSlots
-              , appConfWriteBlocksBlockHashSet = writeBlockHashes
-              , appConfLogFunc = logFunc
-              , appConfRegistry = registry
+              { appConfChainDir = oChainDir,
+                appConfFilePath = oConfigFilePath,
+                appConfReadDiskSnapshot =
+                  DiskSnapshot <$> oReadSnapShotSlotNumber <*> pure oSnapShotSuffix,
+                appConfWriteDiskSnapshots =
+                  DiskSnapshot <$> oWriteSnapShotSlotNumbers <*> pure oSnapShotSuffix,
+                appConfStopSlotNumber = oStopSlotNumber,
+                appConfValidationMode = oValidationMode,
+                appConfWriteBlocksSlotNoSet = writeBlockSlots,
+                appConfWriteBlocksBlockHashSet = writeBlockHashes,
+                appConfLogFunc = logFunc,
+                appConfRegistry = registry
               }
       initializeTime
       void $ runRIO appConf $ runDbStreamerApp $ do
@@ -159,7 +405,7 @@ runApp Opts{..} = do
                 (intersperse "," (map display (Set.toList writeBlockHashes)))
         app <- ask
         withMaybeFile rtsStatsFilePathMaybe $ \rtsStatsHandle ->
-          runRIO (app{dsAppOutDir = oOutDir, dsAppRTSStatsHandle = rtsStatsHandle}) $ do
+          runRIO (app {dsAppOutDir = oOutDir, dsAppRTSStatsHandle = rtsStatsHandle}) $ do
             logInfo $ "Starting to " <> display oCommand
             writeStreamerHeader
             case oCommand of
@@ -167,6 +413,7 @@ runApp Opts{..} = do
               Benchmark -> replayBenchmarkReport
               Stats -> replayEpochStats
               ComputeRewards accountIds -> replayRewards accountIds
+              DumpSnapshot -> dumpLedgerSnapshot
   where
     withMaybeFile mFilePath action =
       case mFilePath of

--- a/src/Cardano/Streamer/Run.hs
+++ b/src/Cardano/Streamer/Run.hs
@@ -24,7 +24,7 @@ import Cardano.Ledger.BaseTypes (
   maxLovelaceSupply,
   securityParameter,
   )
-import Cardano.Ledger.Slot (EpochSize (..), epochInfoSize)
+import Cardano.Ledger.Slot (EpochSize (..), SlotNo (..), epochInfoSize)
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core (
@@ -47,18 +47,32 @@ import Cardano.Ledger.Conway.State (ConwayEraCertState, certVStateL, vsCommittee
 import Cardano.Ledger.Shelley.RewardUpdate (PulsingRewUpdate (..), RewardSnapShot (..), RewardUpdate (..))
 import Cardano.Ledger.Hashes (unKeyHash)
 import Cardano.Crypto.Hash.Class (hashToTextAsHex)
-import Cardano.Ledger.PoolDistr (PoolDistr (..))
-import qualified Cardano.Ledger.PoolDistr as PD
-import Cardano.Ledger.Shelley.API (SnapShot (..), SnapShots (..), Stake (..))
+import Cardano.Ledger.Shelley.API (SnapShot (..), SnapShots (..))
 import Cardano.Ledger.Shelley.LedgerState
-import Cardano.Ledger.State (Obligations (..), obligationCertState, obligationGovState, sumAllStake, sumObligation)
-import qualified Data.VMap as VMap
+import Cardano.Ledger.State (
+  IndividualPoolStake (..),
+  Obligations (..),
+  PoolDistr (..),
+  chainAccountStateL,
+  casTreasuryL,
+  casReservesL,
+  individualPoolStake,
+  individualTotalPoolStake,
+  obligationCertState,
+  obligationGovState,
+  sumAllStake,
+  sumObligation,
+  unPoolDistr,
+  )
 import Cardano.Streamer.Benchmark
 import Cardano.Streamer.Common
 import Cardano.Streamer.Inspection
 import Cardano.Streamer.LedgerState
 import Cardano.Streamer.Producer
 import Cardano.Streamer.ProtocolInfo
+import Cardano.Protocol.Crypto (StandardCrypto)
+import Ouroboros.Consensus.Cardano.Block (CardanoBlock)
+import Ouroboros.Consensus.Config (TopLevelConfig)
 import Ouroboros.Consensus.Node.ProtocolInfo (ProtocolInfo (..))
 import Cardano.Streamer.RTS
 import Cardano.Streamer.Rewards
@@ -71,11 +85,12 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import Data.Char (toLower)
 import qualified Data.List.NonEmpty as NE
-import Control.Monad.Trans.Reader (runReaderT)
 import Data.Functor.Identity (runIdentity)
+import Control.Monad.Trans.Reader (runReaderT)
+import Data.Ratio (denominator, numerator, (%))
 import qualified Data.Map.Strict as Map
 import Lens.Micro ((^.))
-import Ouroboros.Consensus.Ledger.Extended (ledgerState)
+import Ouroboros.Consensus.Ledger.Extended (ExtLedgerState, ledgerState)
 import Ouroboros.Consensus.Shelley.Ledger.Ledger (shelleyLedgerState)
 import Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import Ouroboros.Consensus.Storage.LedgerDB.Snapshots (DiskSnapshot (..))
@@ -107,21 +122,30 @@ replayEpochStats = do
   writeNamedCsv "EpochStats" (epochStatsToNamedCsv epochStats)
   logInfo $ "Final summary: \n    " <> display (fold $ unEpochStats epochStats)
 
-dumpLedgerSnapshot :: RIO App ()
-dumpLedgerSnapshot = do
-  extLedgerState <- ledgerDbTipExtLedgerState
-  app <- ask
+-- | Encode a Rational exactly as {"numerator": n, "denominator": d}.
+rationalToJson :: Rational -> Aeson.Value
+rationalToJson r =
+  Aeson.object
+    [ "numerator" Aeson..= numerator r
+    , "denominator" Aeson..= denominator r
+    ]
+
+-- | Build the JSON snapshot for a given ledger state.
+-- Returns Nothing for Byron.
+-- Returns Just (fullJson, rupdNext) where rupdNext should be threaded to the
+-- next epoch's call as mRupdApplied (it is the reward update that will be
+-- applied at that epoch boundary).
+buildSnapshotJson ::
+  TopLevelConfig (CardanoBlock StandardCrypto) ->
+  Maybe Aeson.Value ->
+  ExtLedgerState (CardanoBlock StandardCrypto) mk ->
+  Maybe (Aeson.Value, Aeson.Value)
+buildSnapshotJson topLevelConfig mRupdApplied extLedgerState =
   let eraName = show $ extLedgerStateCardanoEra extLedgerState
-      mGlobals =
-        globalsFromLedgerConfig
-          (extLedgerStateCardanoEra extLedgerState)
-          extLedgerState
-          (pInfoConfig (dsAppProtocolInfo app))
+      mGlobals = globalsFromLedgerConfig (extLedgerStateCardanoEra extLedgerState) extLedgerState topLevelConfig
       mConwayGov = applyConwayNewEpochState extractConwayGovData extLedgerState
-      maybeData = applyNonByronNewEpochState (extractSnapshotData eraName mGlobals mConwayGov) extLedgerState
-  case maybeData of
-    Just snapshotData -> liftIO $ BSL.putStrLn $ Aeson.encode snapshotData
-    Nothing -> logError "Cannot dump Byron era snapshot"
+      mEpochNonce = extLedgerStateEpochNonce extLedgerState
+   in applyNonByronNewEpochState (extractSnapshotData eraName mGlobals mConwayGov mRupdApplied mEpochNonce) extLedgerState
   where
     extractConwayGovData ::
       (ConwayEraGov era, ConwayEraCertState era) => NewEpochState era -> Aeson.Value
@@ -141,79 +165,93 @@ dumpLedgerSnapshot = do
             , "nextEnactState" Aeson..= nextEnactState
             ]
 
-    extractSnapshotData eraName mGlobals mConwayGov nes =
+    -- Returns (fullJson, rupdData) where rupdData is threaded to the next epoch.
+    extractSnapshotData eraName mGlobals mConwayGov mPrevRupd mEpochNonce nes =
       let epochNum = case nesEL nes of EpochNo n -> n
           epochState = nesEs nes
           poolDistr = nesPd nes
-          accountState = epochState ^. esAccountStateL
-          treasuryAmt = unCoin $ accountState ^. asTreasuryL
-          reservesAmt = unCoin $ accountState ^. asReservesL
+          treasuryAmt = unCoin $ epochState ^. chainAccountStateL . casTreasuryL
+          reservesAmt = unCoin $ epochState ^. chainAccountStateL . casReservesL
 
           -- Extract all 3 snapshots (mark, set, go) and fees
           SnapShots {ssStakeMark = markSnap, ssStakeSet = setSnap, ssStakeGo = goSnap, ssFee = feeCoin} = epochState ^. esSnapshotsL
           fees = unCoin feeCoin
 
           -- Extract deposit obligations
-          obligations = obligationCertState (epochState ^. esLStateL . lsCertStateL)
-                     <> obligationGovState (nes ^. newEpochStateGovStateL)
+          obligations =
+            obligationCertState (epochState ^. esLStateL . lsCertStateL)
+              <> obligationGovState (nes ^. newEpochStateGovStateL)
 
-          -- Extract reward update data, forcing the pulser to completion if needed.
-          -- For SNothing (before stability point), synthesize via startStep.
+          sumRs m =
+            sum
+              [ unCoin (rewardAmount r)
+              | rs_set <- Map.elems m
+              , r <- Set.toList rs_set
+              ] :: Integer
+
+          fromPulsing globals rewsnap@RewardSnapShot {..} pulser =
+            let Coin rPot' = rewFees <> rewDeltaR1
+                (RewardUpdate {rs = forcedRs}, _) =
+                  runIdentity $ runReaderT (completeRupd (Pulsing rewsnap pulser)) globals
+                totalDistributed = sumRs forcedRs
+                deltaR2 = unCoin rewR - totalDistributed
+             in Aeson.object
+                  [ "deltaR1" Aeson..= unCoin rewDeltaR1
+                  , "deltaR2" Aeson..= deltaR2
+                  , "deltaT1" Aeson..= unCoin rewDeltaT1
+                  , "rPot" Aeson..= rPot'
+                  , "rewardPot" Aeson..= unCoin rewR
+                  , "totalDistributed" Aeson..= totalDistributed
+                  ]
+
           rupdData =
-            let sumRs m =
-                  sum
-                    [ unCoin (rewardAmount r)
-                    | rs_set <- Map.elems m
-                    , r <- Set.toList rs_set
-                    ] :: Integer
-                fromPulsing globals rewsnap@RewardSnapShot {..} pulser =
-                  let Coin rPot' = rewFees <> rewDeltaR1
-                      (RewardUpdate {rs = forcedRs}, _) =
-                        runIdentity $ runReaderT (completeRupd (Pulsing rewsnap pulser)) globals
-                      totalDistributed = sumRs forcedRs
-                      deltaR2 = unCoin rewR - totalDistributed
-                   in Aeson.object
-                        [ "deltaR1" Aeson..= unCoin rewDeltaR1
-                        , "deltaR2" Aeson..= deltaR2
-                        , "deltaT1" Aeson..= unCoin rewDeltaT1
-                        , "rPot" Aeson..= rPot'
-                        , "rewardPot" Aeson..= unCoin rewR
-                        , "totalDistributed" Aeson..= totalDistributed
-                        ]
-             in case (nesRu nes, mGlobals) of
-                  (SJust (Complete RewardUpdate {..}), _) ->
-                    let DeltaCoin deltaT1 = deltaT
-                        DeltaCoin deltaRCombined = deltaR
-                     in Aeson.object
-                          [ "deltaT1" Aeson..= deltaT1
-                          , "deltaR" Aeson..= deltaRCombined
-                          , "totalDistributed" Aeson..= sumRs rs
-                          ]
-                  (_, Nothing) -> Aeson.Null
-                  (SJust (Pulsing rewsnap pulser), Just globals) ->
-                    fromPulsing globals rewsnap pulser
-                  (SNothing, Just globals) ->
-                    let pulsing =
-                          startStep
-                            (epochInfoSize (epochInfoPure globals) (nesEL nes))
-                            (nesBprev nes)
-                            (nesEs nes)
-                            (Coin $ fromIntegral $ maxLovelaceSupply globals)
-                            (activeSlotCoeff globals)
-                            (securityParameter globals)
-                     in case pulsing of
-                          Pulsing rewsnap pulser -> fromPulsing globals rewsnap pulser
-                          Complete RewardUpdate {..} ->
-                            Aeson.object ["totalDistributed" Aeson..= sumRs rs]
+            case (nesRu nes, mGlobals) of
+              (SJust (Complete RewardUpdate {..}), _) ->
+                let DeltaCoin deltaT1 = deltaT
+                    DeltaCoin deltaRCombined = deltaR
+                 in Aeson.object
+                      [ "deltaT1" Aeson..= deltaT1
+                      , "deltaR" Aeson..= deltaRCombined
+                      , "totalDistributed" Aeson..= sumRs rs
+                      ]
+              (_, Nothing) -> Aeson.Null
+              (SJust (Pulsing rewsnap pulser), Just globals) ->
+                fromPulsing globals rewsnap pulser
+              (SNothing, Just globals) ->
+                let pulsing =
+                      startStep
+                        (epochInfoSize (epochInfoPure globals) (nesEL nes))
+                        (nesBprev nes)
+                        (nesEs nes)
+                        (Coin $ fromIntegral $ maxLovelaceSupply globals)
+                        (activeSlotCoeff globals)
+                        (securityParameter globals)
+                 in case pulsing of
+                      Pulsing rewsnap pulser -> fromPulsing globals rewsnap pulser
+                      Complete RewardUpdate {..} ->
+                        Aeson.object ["totalDistributed" Aeson..= sumRs rs]
 
-          -- Protocol parameters relevant to reward/treasury calculation
+          -- Eta: performance multiplier. Computed the same way the ledger does
+          -- in startStep: if d >= 0.8 then 1, otherwise blocksMade/expectedBlocks.
+          -- (RewardSnapShot does not store eta, so we derive it from nesBprev.)
+          mEta = mGlobals <&> \globals ->
+            let d = unboundRational (pr ^. ppDG)
+                EpochSize slots = epochInfoSize (epochInfoPure globals) (nesEL nes)
+                n = floor $ (1 - d) * unboundRational (activeSlotVal (activeSlotCoeff globals)) * fromIntegral slots :: Integer
+                BlocksMade bm = nesBprev nes
+                blocksMade = fromIntegral $ Map.foldl' (+) 0 bm :: Integer
+             in if d >= 0.8 || n == 0
+                  then 1 :: Rational
+                  else blocksMade % n
+
+          -- Protocol parameters: encoded as exact rationals, not Double
           pr = epochState ^. prevPParamsEpochStateL
           protoParams =
             Aeson.object
-              [ "rho" Aeson..= (fromRational (unboundRational (pr ^. ppRhoL)) :: Double)
-              , "tau" Aeson..= (fromRational (unboundRational (pr ^. ppTauL)) :: Double)
-              , "d" Aeson..= (fromRational (unboundRational (pr ^. ppDG)) :: Double)
-              , "a0" Aeson..= (fromRational (unboundRational (pr ^. ppA0L)) :: Double)
+              [ "rho" Aeson..= rationalToJson (unboundRational (pr ^. ppRhoL))
+              , "tau" Aeson..= rationalToJson (unboundRational (pr ^. ppTauL))
+              , "d" Aeson..= rationalToJson (unboundRational (pr ^. ppDG))
+              , "a0" Aeson..= rationalToJson (unboundRational (pr ^. ppA0L))
               , "nOpt" Aeson..= (pr ^. ppNOptL)
               , "minPoolCost" Aeson..= unCoin (pr ^. ppMinPoolCostL)
               , "protocolVersion" Aeson..= (pr ^. ppProtocolVersionL)
@@ -230,40 +268,31 @@ dumpLedgerSnapshot = do
           instantaneousRewards =
             epochState ^. esLStateL . lsCertStateL . certDStateL . dsIRewardsL
 
-          -- Eta (performance multiplier) and expected blocks
-          etaAndExpected = mGlobals <&> \globals ->
+          -- expectedBlocks is derived from genesis/pparams; eta comes from the pulser
+          mExpectedBlocks = mGlobals <&> \globals ->
             let d = unboundRational (pr ^. ppDG)
                 EpochSize slots = epochInfoSize (epochInfoPure globals) (nesEL nes)
                 asc = activeSlotCoeff globals
-                expectedBlocks =
-                  floor $ (1 - d) * unboundRational (activeSlotVal asc) * fromIntegral slots :: Integer
-                blocksMadeCount =
-                  fromIntegral $ Map.foldr (+) 0 (unBlocksMade (nesBprev nes)) :: Integer
-                eta :: Double
-                eta
-                  | d >= 0.8 = 1.0
-                  | expectedBlocks == 0 = 1.0
-                  | otherwise = fromIntegral blocksMadeCount / fromIntegral expectedBlocks
-             in (eta, expectedBlocks)
+             in floor $ (1 - d) * unboundRational (activeSlotVal asc) * fromIntegral slots :: Integer
 
-          poolMap = PD.unPoolDistr poolDistr
-          totalStakeRational = sum [PD.individualPoolStake pd | pd <- Map.elems poolMap]
+          -- Pool distribution: stake as exact rational + exact lovelace count.
+          -- The fractions in PoolDistr sum to exactly 1 by ledger construction,
+          -- so stakePercent is simply stakeRational * 100.
+          poolMap = unPoolDistr poolDistr
           poolCount = Map.size poolMap
           poolEntries = map mkPoolEntry (Map.toList poolMap)
             where
               mkPoolEntry (pid, poolData) =
-                let stakeRational = PD.individualPoolStake poolData
-                    percent =
-                      if totalStakeRational > 0
-                        then fromRational (stakeRational / totalStakeRational * 100) :: Double
-                        else 0
+                let stakeRational = individualPoolStake poolData
+                    stakeLovelace = unCoin $ fromCompact (individualTotalPoolStake poolData)
+                    stakePercent = fromRational (stakeRational * 100) :: Double
                  in Aeson.object
-                      [ "poolId" Aeson..= hashToTextAsHex (unKeyHash pid),
-                        "stake" Aeson..= (fromRational stakeRational :: Double),
-                        "stakePercent" Aeson..= percent
+                      [ "poolId" Aeson..= hashToTextAsHex (unKeyHash pid)
+                      , "stake" Aeson..= rationalToJson stakeRational
+                      , "stakeLovelace" Aeson..= (stakeLovelace :: Integer)
+                      , "stakePercent" Aeson..= stakePercent
                       ]
 
-          -- Helper to extract full snapshot data for comparison
           snapshotInfo name mBlocks snap =
             Aeson.object $
               [ "name" Aeson..= (name :: String)
@@ -273,35 +302,85 @@ dumpLedgerSnapshot = do
               ]
                 ++ ["blocks" Aeson..= b | Just b <- [mBlocks]]
 
-       in Aeson.object
-            [ "epoch" Aeson..= (fromIntegral epochNum :: Integer),
-              "snapshotEraName" Aeson..= eraName,
-              "protocolParams" Aeson..= protoParams,
-              "totalStake" Aeson..= totalStake,
-              "activeStake" Aeson..= activeStake,
-              "eta" Aeson..= fmap fst etaAndExpected,
-              "expectedBlocks" Aeson..= fmap snd etaAndExpected,
-              "rupdNext" Aeson..= rupdData,
-              "treasury" Aeson..= treasuryAmt,
-              "reserves" Aeson..= reservesAmt,
-              "totalPools" Aeson..= poolCount,
-              "poolDistribution" Aeson..= poolEntries,
-              "epochFees" Aeson..= fees,
-              "deposits" Aeson..= Aeson.object
-                [ "stakeKey" Aeson..= unCoin (oblStake obligations)
-                , "pool" Aeson..= unCoin (oblPool obligations)
-                , "dRep" Aeson..= unCoin (oblDRep obligations)
-                , "proposal" Aeson..= unCoin (oblProposal obligations)
-                , "total" Aeson..= unCoin (sumObligation obligations)
-                ],
-              "instantaneousRewards" Aeson..= instantaneousRewards,
-              "conwayGov" Aeson..= mConwayGov,
-              "snapshots" Aeson..= Aeson.object
-                [ "mark" Aeson..= snapshotInfo "mark" (Just (nesBcur nes)) markSnap
-                , "set" Aeson..= snapshotInfo "set" (Nothing :: Maybe BlocksMade) setSnap
-                , "go" Aeson..= snapshotInfo "go" (Just (nesBprev nes)) goSnap
-                ]
-            ]
+          json =
+            Aeson.object
+              [ "epoch" Aeson..= (fromIntegral epochNum :: Integer)
+              , "snapshotEraName" Aeson..= eraName
+              , "epochNonce" Aeson..= mEpochNonce
+              , "protocolParams" Aeson..= protoParams
+              , "totalStake" Aeson..= totalStake
+              , "activeStake" Aeson..= activeStake
+              , "eta" Aeson..= fmap rationalToJson mEta
+              , "expectedBlocks" Aeson..= mExpectedBlocks
+              , "rupdNext" Aeson..= rupdData
+              , "rupdApplied" Aeson..= mPrevRupd
+              , "treasury" Aeson..= treasuryAmt
+              , "reserves" Aeson..= reservesAmt
+              , "totalPools" Aeson..= poolCount
+              , "poolDistribution" Aeson..= poolEntries
+              , "epochFees" Aeson..= fees
+              , "deposits"
+                  Aeson..= Aeson.object
+                    [ "stakeKey" Aeson..= unCoin (oblStake obligations)
+                    , "pool" Aeson..= unCoin (oblPool obligations)
+                    , "dRep" Aeson..= unCoin (oblDRep obligations)
+                    , "proposal" Aeson..= unCoin (oblProposal obligations)
+                    , "total" Aeson..= unCoin (sumObligation obligations)
+                    ]
+              , "instantaneousRewards" Aeson..= instantaneousRewards
+              , "conwayGov" Aeson..= mConwayGov
+              , "snapshots"
+                  Aeson..= Aeson.object
+                    [ "mark" Aeson..= snapshotInfo "mark" (Just (nesBcur nes)) markSnap
+                    , "set" Aeson..= snapshotInfo "set" (Nothing :: Maybe BlocksMade) setSnap
+                    , "go" Aeson..= snapshotInfo "go" (Just (nesBprev nes)) goSnap
+                    ]
+              ]
+       in (json, rupdData)
+
+dumpLedgerSnapshot :: RIO App ()
+dumpLedgerSnapshot = do
+  extLedgerState <- ledgerDbTipExtLedgerState
+  app <- ask
+  case buildSnapshotJson (pInfoConfig (dsAppProtocolInfo app)) Nothing extLedgerState of
+    Just (snapshotData, _) -> liftIO $ BSL.putStrLn $ Aeson.encode snapshotData
+    Nothing -> logError "Cannot dump Byron era snapshot"
+
+dumpEpochSnapshots :: RIO App ()
+dumpEpochSnapshots = do
+  app <- ask
+  outDir <-
+    maybe (throwString "--out-dir is required for dump-epoch-snapshots") pure
+      =<< asks dsAppOutDir
+  prevRupdRef <- newIORef Nothing
+  let topLevelConfig = pInfoConfig (dsAppProtocolInfo app)
+      snapshotInspection =
+        noInspection
+          { siFinal = \swb _ _ _ _ _ ->
+              when (isFirstSlotOfNewEpoch swb) $ do
+                prevRupd <- readIORef prevRupdRef
+                -- We use the post-block state (DiffMK) rather than the bare
+                -- epoch-boundary state. This is safe because buildSnapshotJson reads
+                -- exclusively from NewEpochState fields (epoch number, treasury,
+                -- reserves, snapshots, pool distribution, protocol params, reward
+                -- update) — none of which are part of the UTxO table, so the
+                -- unapplied DiffMK diffs are irrelevant.
+                -- INVARIANT: do not add snapshot fields that read from the UTxO
+                -- (esUTxOState / utxosUtxo) without switching to a ValuesMK state.
+                let mResult = buildSnapshotJson topLevelConfig prevRupd (swbNewExtLedgerState swb)
+                forM_ mResult $ \(json, rupdNext) -> do
+                  writeIORef prevRupdRef (Just rupdNext)
+                  let epochStr = show (unEpochNo (swbEpochNo swb))
+                      slotStr = show (unSlotNo (swbSlotNo swb))
+                      fp = outDir </> epochStr <> "-" <> slotStr <> ".json"
+                  liftIO $ BSL.writeFile fp (Aeson.encode json)
+                  logInfo $
+                    "Dumped epoch "
+                      <> display (swbEpochNo swb)
+                      <> " snapshot to: "
+                      <> display (T.pack fp)
+          }
+  runConduit $ sourceBlocksWithInspector_ (SlotInspector snapshotInspection) .| sinkNull
 
 replayRewards :: NE.NonEmpty RewardAccount -> RIO App ()
 replayRewards accounts = do
@@ -414,6 +493,7 @@ runApp Opts {..} = do
               Stats -> replayEpochStats
               ComputeRewards accountIds -> replayRewards accountIds
               DumpSnapshot -> dumpLedgerSnapshot
+              DumpEpochSnapshots -> dumpEpochSnapshots
   where
     withMaybeFile mFilePath action =
       case mFilePath of

--- a/src/Cardano/Streamer/Storage.hs
+++ b/src/Cardano/Streamer/Storage.hs
@@ -14,6 +14,8 @@ module Cardano.Streamer.Storage (
   ledgerDbFlushExtLedgerState,
   ledgerDbStoreSnapshot,
   LedgerDbBackend (..),
+  LedgerDb (..),
+  HasLedgerDb (..),
   ledgerDbStateWithTablesForBlock,
   withImmutableDb,
 )


### PR DESCRIPTION
This PR adds a ledger state dump utility useful for debugging issues happening at the epoch transition. This tool was made using Claude (AI). I've generally reviewed the code for accuracy, but am not skilled enough with Haskell to know whether some of the decisions made were good or not (e.g. using lenses in certain places). I do know that one of the more hacky things in here is the eta implementation being duplicated. This is because it is computed in `startStep` at the beginning of the epoch.